### PR TITLE
Feature inverse

### DIFF
--- a/app/gui/node-editor.cpp
+++ b/app/gui/node-editor.cpp
@@ -1792,7 +1792,10 @@ show_dynamics_inputs(editor& /*ed*/, none& /*dyn*/)
 static void
 show_dynamics_values(simulation& /*sim*/, const filter& dyn)
 {
-    ImGui::Text("%.3f * %.3f", dyn.value, dyn.input_coeff);
+    //ImGui::Text("%.3f, %.3f, %.3f", dyn.default_lower_threshold, dyn.default_upper_threshold, dyn.value);
+    ImGui::Text("%.3f", dyn.default_lower_threshold);
+    ImGui::Text("%.3f", dyn.default_upper_threshold);
+    ImGui::Text("%.3f", dyn.inValue);
 }
 
 static void
@@ -2320,7 +2323,9 @@ show_dynamics_inputs(editor& /*ed*/, accumulator_2& /*dyn*/)
 static void
 show_dynamics_inputs(editor& /*ed*/, filter& dyn)
 {
-    ImGui::InputDouble("coeff-0", &dyn.default_input_coeff);
+    ImGui::InputDouble("Lower threshold ", &dyn.default_lower_threshold);
+    ImGui::InputDouble("Upper threshold ", &dyn.default_upper_threshold);
+    ImGui::InputDouble("Value ", &dyn.inValue);
 }
 
 static void

--- a/app/gui/node-editor.cpp
+++ b/app/gui/node-editor.cpp
@@ -1792,10 +1792,9 @@ show_dynamics_inputs(editor& /*ed*/, none& /*dyn*/)
 static void
 show_dynamics_values(simulation& /*sim*/, const filter& dyn)
 {
-    //ImGui::Text("%.3f, %.3f, %.3f", dyn.default_lower_threshold, dyn.default_upper_threshold, dyn.value);
-    ImGui::Text("%.3f", dyn.default_lower_threshold);
-    ImGui::Text("%.3f", dyn.default_upper_threshold);
-    ImGui::Text("%.3f", dyn.inValue);
+    ImGui::Text("%.3f", dyn.lower_threshold[0]);
+    ImGui::Text("%.3f", dyn.upper_threshold[0]);
+    ImGui::Text("%.3f", dyn.inValue[0]);
 }
 
 static void
@@ -2323,9 +2322,9 @@ show_dynamics_inputs(editor& /*ed*/, accumulator_2& /*dyn*/)
 static void
 show_dynamics_inputs(editor& /*ed*/, filter& dyn)
 {
-    ImGui::InputDouble("Lower threshold ", &dyn.default_lower_threshold);
-    ImGui::InputDouble("Upper threshold ", &dyn.default_upper_threshold);
-    ImGui::InputDouble("Value ", &dyn.inValue);
+    ImGui::InputDouble("Lower threshold ", &dyn.default_lower_threshold[0]);
+    ImGui::InputDouble("Upper threshold ", &dyn.default_upper_threshold[0]);
+    //ImGui::InputDouble("Value ", &dyn.inValue[0]);
 }
 
 static void

--- a/app/gui/node-editor.cpp
+++ b/app/gui/node-editor.cpp
@@ -1792,7 +1792,7 @@ show_dynamics_inputs(editor& /*ed*/, none& /*dyn*/)
 static void
 show_dynamics_values(simulation& /*sim*/, const filter& dyn)
 {
-    ImGui::Text("number %ld", dyn.x);
+    ImGui::Text("%.3f * %.3f", dyn.value, dyn.input_coeff);
 }
 
 static void
@@ -2318,8 +2318,10 @@ show_dynamics_inputs(editor& /*ed*/, accumulator_2& /*dyn*/)
 {}
 
 static void
-show_dynamics_inputs(editor& /*ed*/, filter& /*dyn*/)
-{}
+show_dynamics_inputs(editor& /*ed*/, filter& dyn)
+{
+    ImGui::InputDouble("coeff-0", &dyn.default_input_coeff);
+}
 
 static void
 show_dynamics_inputs(editor& /*ed*/, flow& /*dyn*/)

--- a/app/gui/node-editor.cpp
+++ b/app/gui/node-editor.cpp
@@ -1699,6 +1699,12 @@ show_dynamics_values(simulation& /*sim*/, const priority_queue& dyn)
 }
 
 static void
+show_dynamics_values(simulation& /*sim*/, const pwr_inverse& dyn)
+{
+    ImGui::Text("Value %.3f", dyn.inValue[0]);
+}
+
+static void
 show_dynamics_values(simulation& /*sim*/, const generator& dyn)
 {
     ImGui::Text("next %.3f", dyn.sigma);
@@ -2223,6 +2229,12 @@ show_dynamics_inputs(editor& ed, priority_queue& dyn)
 }
 
 static void
+show_dynamics_inputs(editor& ed, pwr_inverse& dyn)
+{
+    ImGui::InputDouble("Value",&dyn.default_value);
+}
+
+static void
 show_dynamics_inputs(editor& ed, generator& dyn)
 {
     ImGui::InputDouble("offset", &dyn.default_offset);
@@ -2687,6 +2699,7 @@ editor::show_editor() noexcept
             add_popup_menuitem(*this, dynamics_type::dynamic_queue, &new_model);
             add_popup_menuitem(
               *this, dynamics_type::priority_queue, &new_model);
+            add_popup_menuitem(*this, dynamics_type::pwr_inverse, &new_model);
             add_popup_menuitem(*this, dynamics_type::generator, &new_model);
             add_popup_menuitem(*this, dynamics_type::constant, &new_model);
             add_popup_menuitem(*this, dynamics_type::time_func, &new_model);

--- a/app/gui/node-editor.cpp
+++ b/app/gui/node-editor.cpp
@@ -1792,8 +1792,8 @@ show_dynamics_inputs(editor& /*ed*/, none& /*dyn*/)
 static void
 show_dynamics_values(simulation& /*sim*/, const filter& dyn)
 {
-    ImGui::Text("%.3f", dyn.lower_threshold[0]);
-    ImGui::Text("%.3f", dyn.upper_threshold[0]);
+    ImGui::Text("%.3f", dyn.lower_threshold);
+    ImGui::Text("%.3f", dyn.upper_threshold);
     ImGui::Text("%.3f", dyn.inValue[0]);
 }
 
@@ -2322,8 +2322,8 @@ show_dynamics_inputs(editor& /*ed*/, accumulator_2& /*dyn*/)
 static void
 show_dynamics_inputs(editor& /*ed*/, filter& dyn)
 {
-    ImGui::InputDouble("Lower threshold ", &dyn.default_lower_threshold[0]);
-    ImGui::InputDouble("Upper threshold ", &dyn.default_upper_threshold[0]);
+    ImGui::InputDouble("Lower threshold ", &dyn.default_lower_threshold);
+    ImGui::InputDouble("Upper threshold ", &dyn.default_upper_threshold);
     //ImGui::InputDouble("Value ", &dyn.inValue[0]);
 }
 

--- a/lib/include/irritator/core.hpp
+++ b/lib/include/irritator/core.hpp
@@ -5226,30 +5226,28 @@ struct filter {
     port y[1];
     time sigma;
 
-    irt::message default_lower_threshold;
-    irt::message default_upper_threshold;
+    double default_lower_threshold;
+    double default_upper_threshold;
 
-    irt::message lower_threshold;
-    irt::message upper_threshold;
+    double lower_threshold;
+    double upper_threshold;
     irt::message inValue ;
 
 
     filter() noexcept {
-        default_lower_threshold[0] = -0.5;
-        default_upper_threshold[0] = 0.5;
+        default_lower_threshold = -0.5;
+        default_upper_threshold = 0.5;
         sigma=time_domain<time>::infinity;
     }
 
     status initialize() noexcept { 
         sigma = time_domain<time>::infinity;
-        lower_threshold[0]=default_lower_threshold[0];
-        upper_threshold[0]=default_upper_threshold[0];
+        lower_threshold=default_lower_threshold;
+        upper_threshold=default_upper_threshold;
         //inValue[0]=0.0;
-        irt_return_if_fail(default_lower_threshold[0] < default_upper_threshold[0],
+        irt_return_if_fail(default_lower_threshold < default_upper_threshold,
                            status::filter_threshold_condition_not_satisfied);
-        if (!(lower_threshold[0] < upper_threshold[0])) {
-            irt_return_if_bad(status::filter_threshold_condition_not_satisfied);
-        }
+
         return status::success;
     }
 
@@ -5263,16 +5261,16 @@ struct filter {
         sigma = time_domain<time>::infinity;
         if (!x[0].messages.empty()) {
             auto& msg=x[0].messages.front();
-            if (inValue[0] > lower_threshold[0] &&
-                inValue[0] < upper_threshold[0]) {
+
+            if (msg[0] > lower_threshold &&
+                msg[0] < upper_threshold) {
                 inValue[0] = msg[0];
-            } else if (inValue[0] < lower_threshold[0] &&
-                       inValue[0] < upper_threshold[0]) {
-                lower_threshold[0]=msg[1];
-                inValue[0]=lower_threshold[0];
+            }
+            else if (msg[1] < lower_threshold &&
+                       msg[1] < upper_threshold) {
+                inValue[0] = msg[1];
             } else {
-                upper_threshold[0]=msg[2];
-                inValue[0]=upper_threshold[0];
+                inValue[0] = msg[2];
             }
 
             sigma = time_domain<time>::zero;

--- a/lib/include/irritator/core.hpp
+++ b/lib/include/irritator/core.hpp
@@ -5221,74 +5221,77 @@ struct constant
 };
 
 struct filter {
+    static const size_t nPort=3;
     port x[1];
     port y[1];
     time sigma;
 
-    double default_lower_threshold;
-    double default_upper_threshold;
-
-    double lower_threshold;
-    double upper_threshold;
-
-    double default_value;
-    double default_input_coeff;
-
-    double value;
-    double input_coeff;
-
-    //filter() noexcept { 
-    //    default_lower_threshold=0.0;
-    //    default_upper_threshold = 1.0;
-    //    default_input_coeff=1.0;
-    //    default_value=0.0;
-
-    //}
+    double default_lower_threshold ;
+    double default_upper_threshold ;
+    double inValue ;
+    double defaultValues[nPort];
 
     status initialize() noexcept { 
-        default_lower_threshold = 0.0;
-        default_upper_threshold = 1.0;
-        default_input_coeff = 1.0;
-        default_value = 0.0;
-        lower_threshold=default_lower_threshold;
-        upper_threshold=default_upper_threshold;
-        input_coeff=default_input_coeff;
-        value=default_value; 
+        default_lower_threshold=-0.05;
+        default_upper_threshold=1.0;
+        inValue=0.0;
+        defaultValues[0] = default_lower_threshold;
+        defaultValues[1] = default_upper_threshold;
+        defaultValues[2] = inValue;
 
+        //std::fill_n(
+        //  std::begin(defaultValues),
+        //            nPort,
+        //            1.0 / static_cast<double>(nPort));
+
+        //std::copy_n(std::begin(inPortValues), nPort, std::begin(values));
+        sigma = time_domain<time>::infinity;
         return status::success;
     }
 
     status lambda() noexcept {
         double to_send=0.0;
-        if ((value >= lower_threshold) && (value <= upper_threshold)) {
-            to_send = value*input_coeff;
+        if (inValue > default_lower_threshold &&
+            inValue < default_upper_threshold) {
+            to_send = inValue;
+            y[0].messages.emplace_front(to_send);
+        } else if (inValue < default_lower_threshold &&
+                   inValue < default_upper_threshold) {
+            to_send = (default_lower_threshold + default_upper_threshold) / 2;
+            y[0].messages.emplace_front(to_send);
+        } 
+        else if (inValue > default_lower_threshold &&
+                   inValue > default_upper_threshold) {
+            to_send = (default_lower_threshold + default_upper_threshold) / 2;
+            y[0].messages.emplace_front(to_send);
         }
-        y[0].messages.emplace_front(to_send);
-
         return status::success;
     }
 
     status transition(time, time, time) noexcept {
         bool have_message = false;
 
-for (const auto& msg : x[0].messages) {
-            value = msg.real[0];
-
+        for (const auto& msg : x[0].messages) {
+            inValue = msg.real[0];
             have_message = true;
         }
 
         sigma =
           have_message ? time_domain<time>::zero : time_domain<time>::infinity;
 
-
         return status::success;
     }
 
     message observation(const time) const noexcept {
-        double ret = 0.0;
-        ret += input_coeff * value;
+        double ret = 0.0; 
+        //for (size_t ii = 0; ii != nPort; ++ii) {
+        //    ret += defaultValues[ii];
+        //    //return ret;
+        //    return { ret }; // if returning an array
+        //}
+        ret = inValue;
         return ret;
-        //return { ret };
+
     }
 };
 

--- a/lib/include/irritator/io.hpp
+++ b/lib/include/irritator/io.hpp
@@ -1515,7 +1515,8 @@ private:
 
     bool read(simulation& /*sim*/, filter& dyn) noexcept
     {
-        return !!(is >> dyn.default_value >> dyn.default_input_coeff);
+        return !!(is >> dyn.default_lower_threshold >> dyn.default_upper_threshold >>
+                  dyn.inValue);
     }
 
     bool read(simulation& /*sim*/, flow& dyn) noexcept
@@ -2113,7 +2114,9 @@ private:
 
     void write(const simulation& /*sim*/, const filter& dyn) noexcept
     {
-        os << "filter"<<dyn.default_value<<' '<<dyn.default_input_coeff <<'\n';
+        os << "filter " << dyn.default_lower_threshold << ' ' << dyn.default_upper_threshold
+           << ' ' << dyn.inValue
+           << '\n';
     }
 
     void write(const simulation& /*sim*/, const flow& dyn) noexcept

--- a/lib/include/irritator/io.hpp
+++ b/lib/include/irritator/io.hpp
@@ -1515,8 +1515,8 @@ private:
 
     bool read(simulation& /*sim*/, filter& dyn) noexcept
     {
-        return !!(is >> dyn.default_lower_threshold[0] >>
-                  dyn.default_upper_threshold[0]);
+        return !!(is >> dyn.default_lower_threshold >>
+                  dyn.default_upper_threshold);
     }
 
     bool read(simulation& /*sim*/, flow& dyn) noexcept
@@ -2114,8 +2114,8 @@ private:
 
     void write(const simulation& /*sim*/, const filter& dyn) noexcept
     {
-        os << "filter " << dyn.default_lower_threshold[0] << ' '
-           << dyn.default_upper_threshold[0]
+        os << "filter " << dyn.default_lower_threshold << ' '
+           << dyn.default_upper_threshold
            << '\n';
     }
 

--- a/lib/include/irritator/io.hpp
+++ b/lib/include/irritator/io.hpp
@@ -1513,9 +1513,9 @@ private:
         return true;
     }
 
-    bool read(simulation& /*sim*/, filter& /*dyn*/) noexcept
+    bool read(simulation& /*sim*/, filter& dyn) noexcept
     {
-        return true;
+        return !!(is >> dyn.default_value >> dyn.default_input_coeff);
     }
 
     bool read(simulation& /*sim*/, flow& dyn) noexcept
@@ -2111,9 +2111,9 @@ private:
            << (dyn.default_f == &time_function ? "time\n" : "square\n");
     }
 
-    void write(const simulation& /*sim*/, const filter& /*dyn*/) noexcept
+    void write(const simulation& /*sim*/, const filter& dyn) noexcept
     {
-        os << "filter\n";
+        os << "filter"<<dyn.default_value<<' '<<dyn.default_input_coeff <<'\n';
     }
 
     void write(const simulation& /*sim*/, const flow& dyn) noexcept

--- a/lib/include/irritator/io.hpp
+++ b/lib/include/irritator/io.hpp
@@ -46,7 +46,7 @@ static inline const char* dynamics_type_names[] = { "none",
                                                     "qss3_square",
                                                     "qss3_sum_2",
                                                     "qss3_sum_3",
-                                                    "qss3_sum_4",
+                                                    "qss3_sum_4", 
                                                     "qss3_wsum_2",
                                                     "qss3_wsum_3",
                                                     "qss3_wsum_4",
@@ -62,13 +62,14 @@ static inline const char* dynamics_type_names[] = { "none",
                                                     "queue",
                                                     "dynamic_queue",
                                                     "priority_queue",
+                                                    "pwr_inverse",
                                                     "generator",
                                                     "constant",
                                                     "cross",
                                                     "time_func",
                                                     "accumulator_2",
                                                     "filter",
-                                                    "flow" };
+                                                    "flow"};
 
 static_assert(std::size(dynamics_type_names) ==
               static_cast<sz>(dynamics_type_size()));
@@ -142,6 +143,7 @@ get_input_port_names() noexcept
                   std::is_same_v<Dynamics, queue> ||
                   std::is_same_v<Dynamics, dynamic_queue> ||
                   std::is_same_v<Dynamics, priority_queue> ||
+                  std::is_same_v<Dynamics, pwr_inverse> ||
                   std::is_same_v<Dynamics, qss1_power> ||
                   std::is_same_v<Dynamics, qss2_power> ||
                   std::is_same_v<Dynamics, qss3_power> ||
@@ -222,6 +224,7 @@ get_input_port_names(const dynamics_type type) noexcept
     case dynamics_type::queue:
     case dynamics_type::dynamic_queue:
     case dynamics_type::priority_queue:
+    case dynamics_type::pwr_inverse:
     case dynamics_type::qss1_power:
     case dynamics_type::qss2_power:
     case dynamics_type::qss3_power:
@@ -303,6 +306,7 @@ get_output_port_names() noexcept
                   std::is_same_v<Dynamics, queue> ||
                   std::is_same_v<Dynamics, dynamic_queue> ||
                   std::is_same_v<Dynamics, priority_queue> ||
+                  std::is_same_v<Dynamics, pwr_inverse> ||
                   std::is_same_v<Dynamics, generator> ||
                   std::is_same_v<Dynamics, constant> ||
                   std::is_same_v<Dynamics, time_func> ||
@@ -371,6 +375,7 @@ get_output_port_names(const dynamics_type type) noexcept
     case dynamics_type::queue:
     case dynamics_type::dynamic_queue:
     case dynamics_type::priority_queue:
+    case dynamics_type::pwr_inverse:
     case dynamics_type::generator:
     case dynamics_type::constant:
     case dynamics_type::time_func:
@@ -979,6 +984,7 @@ private:
             { "mult_4", dynamics_type::mult_4 },
             { "none", dynamics_type::none },
             { "priority_queue", dynamics_type::priority_queue },
+            { "pwr_inverse", dynamics_type::pwr_inverse },
             { "qss1_cross", dynamics_type::qss1_cross },
             { "qss1_integrator", dynamics_type::qss1_integrator },
             { "qss1_multiplier", dynamics_type::qss1_multiplier },
@@ -1412,6 +1418,11 @@ private:
         }
 
         return true;
+    }
+
+    bool read(simulation& sim, pwr_inverse& dyn) noexcept
+    {
+        return !!(is >> dyn.default_value);
     }
 
     bool read(simulation& sim, generator& dyn) noexcept
@@ -2034,6 +2045,11 @@ private:
         os << "priority_queue ";
         write(dyn.default_source_ta);
         os << '\n';
+    }
+
+    void write(const simulation& /*sim*/, const pwr_inverse& dyn) noexcept
+    {
+        os << "pwr_inverse " << dyn.default_value << ' ';
     }
 
     void write(const simulation& /*sim*/, const generator& dyn) noexcept

--- a/lib/include/irritator/io.hpp
+++ b/lib/include/irritator/io.hpp
@@ -1515,8 +1515,8 @@ private:
 
     bool read(simulation& /*sim*/, filter& dyn) noexcept
     {
-        return !!(is >> dyn.default_lower_threshold >> dyn.default_upper_threshold >>
-                  dyn.inValue);
+        return !!(is >> dyn.default_lower_threshold[0] >>
+                  dyn.default_upper_threshold[0]);
     }
 
     bool read(simulation& /*sim*/, flow& dyn) noexcept
@@ -2114,8 +2114,8 @@ private:
 
     void write(const simulation& /*sim*/, const filter& dyn) noexcept
     {
-        os << "filter " << dyn.default_lower_threshold << ' ' << dyn.default_upper_threshold
-           << ' ' << dyn.inValue
+        os << "filter " << dyn.default_lower_threshold[0] << ' '
+           << dyn.default_upper_threshold[0]
            << '\n';
     }
 


### PR DESCRIPTION
Feature inverse is meant to compute the inverse of any input to the atomic block. This feature is needed for most of the simulation of the PPR models. I found it was directly absent in the qss3 solver